### PR TITLE
Fixes to run Quickroute with Mono 4.6

### DIFF
--- a/QuickRoute.BusinessEntities/Exporters/ImageExporter.cs
+++ b/QuickRoute.BusinessEntities/Exporters/ImageExporter.cs
@@ -142,7 +142,11 @@ namespace QuickRoute.BusinessEntities.Exporters
         DrawColorRange(g, colorRangeScaleFont, routeLineSettings, colorRangeScaleBrush);
       }
 
+// Bitmap.SetResolution does not work in Mono
+// https://bugzilla.novell.com/show_bug.cgi?id=434583
+#if !__MonoCS__
       Image.SetResolution(Document.Map.Image.HorizontalResolution, Document.Map.Image.VerticalResolution);
+#endif
 
       // dispose objects
       borderPen.Dispose();
@@ -228,6 +232,7 @@ namespace QuickRoute.BusinessEntities.Exporters
 
     private void SetExifData()
     {
+#if !__MonoCS__
       // GPS version
       var image = Image;
       var exif = new ExifWorks.ExifWorks(ref image);
@@ -255,6 +260,7 @@ namespace QuickRoute.BusinessEntities.Exporters
       }
 
       exif.SetPropertyString((int)ExifWorks.ExifWorks.TagNames.SoftwareUsed, Strings.QuickRoute + " " + Document.GetVersionString());
+#endif
     }
 
     private void SetQuickRouteExtensionData()

--- a/QuickRoute.Controls/Canvas.cs
+++ b/QuickRoute.Controls/Canvas.cs
@@ -661,7 +661,6 @@ namespace QuickRoute.Controls
     {
       if (document != null && document.Map != null)
       {
-        Console.WriteLine("ResizeCanvas");
         UpdateScrollbarProperties();
         if (!scrXPanel.Visible) scrX.Value = scrX.Minimum;
         if (!scrY.Visible) scrY.Value = scrY.Minimum;

--- a/QuickRoute.Resources/Images.resx
+++ b/QuickRoute.Resources/Images.resx
@@ -119,6 +119,6 @@
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="HeaderLogo" type="System.Resources.ResXFileRef, System.Windows.Forms">
-    <value>resources\headerlogo.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
+    <value>Resources\HeaderLogo.png;System.Drawing.Bitmap, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a</value>
   </data>
 </root>

--- a/QuickRoute.UI/Classes/Util.cs
+++ b/QuickRoute.UI/Classes/Util.cs
@@ -129,9 +129,14 @@ namespace QuickRoute.UI.Classes
 
     public static string PathShortener(string path, int length)
     {
+#if __MonoCS__
+      //FIXME - implement some shortening
+      return path;
+#else
       var sb = new StringBuilder();
       PathCompactPathEx(sb, path, length, 0);
       return sb.ToString();
+#endif
     }
 
     public static void InsertIntoRecentDocumentsList(string fileName)

--- a/QuickRoute.UI/Main.cs
+++ b/QuickRoute.UI/Main.cs
@@ -1379,8 +1379,8 @@ namespace QuickRoute.UI
       updatingUINowCounter++;
       laps.RowCount = 0;
       laps.ColumnCount = 0;
-      laps.RowCount = lapInfoList.Count;
       laps.ColumnCount = (lapInfoList.Count == 0 ? 0 : lapInfoList[0].GetProperties().Count);
+      laps.RowCount = lapInfoList.Count;
       updatingUINowCounter--;
       SetLapGridHeaders();
       SortLapGrid();


### PR DESCRIPTION
These fixes were necessary to run Quickroute with Mono 4.6 on Linux.  The only part I was unable to test reliably is the replacement of high performance counters with Stopwatch.  With these fixes Quickroute provides at least basic functionality.